### PR TITLE
Add tests and achieve coverage above threshold

### DIFF
--- a/.github/workflows/git-build.yml
+++ b/.github/workflows/git-build.yml
@@ -1,0 +1,21 @@
+name: git-build
+
+on:
+  [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v1
+      with:
+        node-version: '16.16.0'
+    - run: npm ci
+    - run: npm run coverage
+    - name: Coveralls
+      uses: coverallsapp/github-action@master
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.nycrc
+++ b/.nycrc
@@ -1,0 +1,7 @@
+{
+    "lines": 80,
+    "statements": 80,
+    "functions": 80,
+    "branches": 80,
+    "check-coverage": true
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "swagger-ui-express": "^4.5.0"
       },
       "devDependencies": {
+        "chai": "^4.3.6",
         "eslint": "^8.20.0",
         "eslint-config-google": "^0.14.0",
         "husky": "^8.0.1",
@@ -940,6 +941,15 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/async": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
@@ -1156,6 +1166,24 @@
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "optional": true
     },
+    "node_modules/chai": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.6.tgz",
+      "integrity": "sha512-bbcp3YfHCUzMOvKqsztczerVgBKSsEijCySNlHHbX3VG1nskvqjz5Rfso1gGwD6w6oOV3eI60pKuMOV5MV7p3Q==",
+      "dev": true,
+      "dependencies": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^3.0.1",
+        "get-func-name": "^2.0.0",
+        "loupe": "^2.3.1",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.0.5"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1182,6 +1210,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==",
+      "dev": true,
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/chokidar": {
@@ -1502,6 +1539,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.12"
       }
     },
     "node_modules/deep-extend": {
@@ -2324,6 +2373,15 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
@@ -3114,6 +3172,15 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true
+    },
+    "node_modules/loupe": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.4.tgz",
+      "integrity": "sha512-OvKfgCC2Ndby6aSTREl5aCCPTNIzlDfQZvZxNUrBrihDhL3xcrYegTblhmEiCrg2kKQz4XsFIaemE5BF4ybSaQ==",
+      "dev": true,
+      "dependencies": {
+        "get-func-name": "^2.0.0"
+      }
     },
     "node_modules/lru-cache": {
       "version": "6.0.0",
@@ -4042,6 +4109,15 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+    },
+    "node_modules/pathval": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/performance-now": {
       "version": "2.1.0",
@@ -4982,6 +5058,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/type-fest": {
@@ -6120,6 +6205,12 @@
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
       "optional": true
     },
+    "assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true
+    },
     "async": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
@@ -6277,6 +6368,21 @@
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "optional": true
     },
+    "chai": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.6.tgz",
+      "integrity": "sha512-bbcp3YfHCUzMOvKqsztczerVgBKSsEijCySNlHHbX3VG1nskvqjz5Rfso1gGwD6w6oOV3eI60pKuMOV5MV7p3Q==",
+      "dev": true,
+      "requires": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^3.0.1",
+        "get-func-name": "^2.0.0",
+        "loupe": "^2.3.1",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.0.5"
+      }
+    },
     "chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -6297,6 +6403,12 @@
           }
         }
       }
+    },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==",
+      "dev": true
     },
     "chokidar": {
       "version": "3.5.3",
@@ -6563,6 +6675,15 @@
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
       "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
       "dev": true
+    },
+    "deep-eql": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "^4.0.0"
+      }
     },
     "deep-extend": {
       "version": "0.6.0",
@@ -7183,6 +7304,12 @@
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
     },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==",
+      "dev": true
+    },
     "get-intrinsic": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
@@ -7779,6 +7906,15 @@
           "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
           "dev": true
         }
+      }
+    },
+    "loupe": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.4.tgz",
+      "integrity": "sha512-OvKfgCC2Ndby6aSTREl5aCCPTNIzlDfQZvZxNUrBrihDhL3xcrYegTblhmEiCrg2kKQz4XsFIaemE5BF4ybSaQ==",
+      "dev": true,
+      "requires": {
+        "get-func-name": "^2.0.0"
       }
     },
     "lru-cache": {
@@ -8496,6 +8632,12 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
     },
+    "pathval": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "dev": true
+    },
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -9209,6 +9351,12 @@
       "requires": {
         "prelude-ls": "^1.2.1"
       }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
     },
     "type-fest": {
       "version": "0.20.2",

--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
     "test": "tests"
   },
   "scripts": {
-    "test": "npm run coverage && npm run lint",
+    "test": "nyc mocha tests && npm run lint",
     "start": "node index.js",
-    "coverage": "nyc mocha tests",
+    "coverage": "nyc mocha tests && nyc report --reporter=lcov",
     "lint": "eslint .",
     "prepare": "husky install"
   },

--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
     "test": "tests"
   },
   "scripts": {
-    "test": "mocha tests && npm run lint",
+    "test": "npm run coverage && npm run lint",
     "start": "node index.js",
-    "coverage": "nyc npm run test",
+    "coverage": "nyc mocha tests",
     "lint": "eslint .",
     "prepare": "husky install"
   },
@@ -25,6 +25,7 @@
     "swagger-ui-express": "^4.5.0"
   },
   "devDependencies": {
+    "chai": "^4.3.6",
     "eslint": "^8.20.0",
     "eslint-config-google": "^0.14.0",
     "husky": "^8.0.1",

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -8,6 +8,8 @@ const db = new sqlite3.Database(':memory:');
 const app = require('../src/app')(db);
 const buildSchemas = require('../src/schemas');
 
+const {expect} = require('chai');
+
 describe('API tests', () => {
   before((done) => {
     db.serialize((err) => {
@@ -27,6 +29,180 @@ describe('API tests', () => {
           .get('/health')
           .expect('Content-Type', /text/)
           .expect(200, done);
+    });
+  });
+
+  describe('GET /rides', () => {
+    it('should return rides not found', (done) => {
+      request(app)
+          .get('/rides')
+          .expect('Content-Type', /json/)
+          .expect(404, done);
+    });
+  });
+
+  describe('GET /rides/1', () => {
+    it('should return ride not found', (done) => {
+      request(app)
+          .get('/rides/1')
+          .expect('Content-Type', /json/)
+          .expect(404, done);
+    });
+  });
+
+  describe('POST /rides', () => {
+    it('should return invalid startLatitude', (done) => {
+      request(app)
+          .post('/rides')
+          .send({
+            start_lat: '-91',
+            start_long: '-180',
+            end_lat: '-90',
+            end_long: '-180',
+            rider_name: 'John Doe',
+            driver_name: 'Jane Doe',
+            driver_vehicle: 'BMW',
+          })
+          .expect('Content-Type', /json/)
+          .expect(400, done);
+    });
+  });
+
+  describe('POST /rides', () => {
+    it('should return invalid endLatitude', (done) => {
+      request(app)
+          .post('/rides')
+          .send({
+            start_lat: '-90',
+            start_long: '-180',
+            end_lat: '-91',
+            end_long: '-180',
+            rider_name: 'John Doe',
+            driver_name: 'Jane Doe',
+            driver_vehicle: 'BMW',
+          })
+          .expect('Content-Type', /json/)
+          .expect(400, done);
+    });
+  });
+
+  describe('POST /rides', () => {
+    it('should return invalid driver name', (done) => {
+      request(app)
+          .post('/rides')
+          .send({
+            start_lat: '-90',
+            start_long: '-180',
+            end_lat: '-90',
+            end_long: '-180',
+            rider_name: 'John Doe',
+            driver_name: '',
+            driver_vehicle: 'BMW',
+          })
+          .expect('Content-Type', /json/)
+          .expect(400, done);
+    });
+  });
+
+  describe('POST /rides', () => {
+    it('should return invalid driver vehicle', (done) => {
+      request(app)
+          .post('/rides')
+          .send({
+            start_lat: '-90',
+            start_long: '-180',
+            end_lat: '-90',
+            end_long: '-180',
+            rider_name: 'John Doe',
+            driver_name: 'fajrin',
+            driver_vehicle: '',
+          })
+          .expect('Content-Type', /json/)
+          .expect(400, done);
+    });
+  });
+
+  describe('POST /rides', () => {
+    it('should return server error no lat/long provided', (done) => {
+      request(app)
+          .post('/rides')
+          .send({
+            start_lat: NaN,
+            start_long: '-180',
+            end_lat: '-90',
+            end_long: '-180',
+            rider_name: 'John Doe',
+            driver_name: 'fajrin',
+            driver_vehicle: 'BMW',
+          })
+          .expect('Content-Type', /json/)
+          .expect(500, done);
+    });
+  });
+
+  describe('POST /rides', () => {
+    it('success creating rides', (done) => {
+      request(app)
+          .post('/rides')
+          .send({
+            start_lat: '-65',
+            start_long: '-173',
+            end_lat: '-27',
+            end_long: '-180',
+            rider_name: 'John Doe',
+            driver_name: 'fajrin',
+            driver_vehicle: 'BMW',
+          })
+          .expect('Content-Type', /json/)
+          .expect(200, done)
+          .then((res) => {
+            expect(res.body[0].rideID).to.be.a('number');
+            expect(res.body[0].startLat).to.deep.equal(-65);
+            expect(res.body[0].startLong).to.deep.equal(-173);
+            expect(res.body[0].endLat).to.deep.equal(-27);
+            expect(res.body[0].endLong).to.deep.equal(-180);
+            expect(res.body[0].riderName).to.deep.equal('John Doe');
+            expect(res.body[0].driverName).to.deep.equal('fajrin');
+            expect(res.body[0].driverVehicle).to.deep.equal('BMW');
+          });
+    });
+  });
+
+  describe('GET /rides', () => {
+    it('should return rides found', (done) => {
+      request(app)
+          .get('/rides')
+          .expect('Content-Type', /json/)
+          .expect(200, done)
+          .then((res) => {
+            expect(res.body[0].rideID).to.be.a('number');
+            expect(res.body[0].startLat).to.deep.equal(-65);
+            expect(res.body[0].startLong).to.deep.equal(-173);
+            expect(res.body[0].endLat).to.deep.equal(-27);
+            expect(res.body[0].endLong).to.deep.equal(-180);
+            expect(res.body[0].riderName).to.deep.equal('John Doe');
+            expect(res.body[0].driverName).to.deep.equal('fajrin');
+            expect(res.body[0].driverVehicle).to.deep.equal('BMW');
+          });
+    });
+  });
+
+  describe('GET /rides/1', () => {
+    it('should return ride found', (done) => {
+      request(app)
+          .get('/rides/1')
+          .expect('Content-Type', /json/)
+          .expect(200, done)
+          .then((res) => {
+            expect(res.body[0].rideID).to.be.a('number');
+            expect(res.body[0].startLat).to.deep.equal(-65);
+            expect(res.body[0].startLong).to.deep.equal(-173);
+            expect(res.body[0].endLat).to.deep.equal(-27);
+            expect(res.body[0].endLong).to.deep.equal(-180);
+            expect(res.body[0].riderName).to.deep.equal('John Doe');
+            expect(res.body[0].driverName).to.deep.equal('fajrin');
+            expect(res.body[0].driverVehicle).to.deep.equal('BMW');
+          });
     });
   });
 });


### PR DESCRIPTION
- Integrate `mocha` test and `nyc` coverage check with `npm test`
- Set test coverage threshold to 80
- Add tests and achieve coverage above threshold
- Integrate build, test, and coverage with github actions and coveralls.io